### PR TITLE
PLATOPS-1568: Upgrade bootstrap-play-25

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -8,7 +8,7 @@ object AppDependencies {
   val compile = Seq(
     "uk.gov.hmrc" %% "play-reactivemongo" % "6.2.0",
     ws,
-    "uk.gov.hmrc" %% "bootstrap-play-25" % "1.8.0"
+    "uk.gov.hmrc" %% "bootstrap-play-25" % "2.0.0"
   )
 
   def test(scope: String = "test") = Seq(


### PR DESCRIPTION
This PR updates bootstrap-play-25 to latest version. We have released a change to bootstrap that is backwards incompatible but we didn't bump the major version. You have created a new service and got it before we fixed it. We would like to remove the library to avoid confusion for other teams but this would cause your service to not compile anymore as library would not be pulled.