### PR TITLE
PODS-1511: Create PSA Association

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -33,6 +33,7 @@ class AppConfig @Inject()(override val runModeConfiguration: Configuration, envi
   lazy val registerWithIdOrganisationUrl: String = s"$baseURL${runModeConfiguration.underlying.getString("serviceUrls.register.with.id.organisation")}"
   lazy val psaMinimalDetailsUrl: String = s"$baseURL${runModeConfiguration.underlying.getString("serviceUrls.psa.minimal.details")}"
   lazy val psaSubscriptionDetailsUrl: String = s"$baseURL${runModeConfiguration.underlying.getString("serviceUrls.psa.subscription.details")}"
+  lazy val createPsaAssociationUrl: String = s"$baseURL${runModeConfiguration.underlying.getString("serviceUrls.createPsaAssociation")}"
   lazy val desEnvironment: String = runModeConfiguration.getString("microservice.services.des-hod.env").getOrElse("local")
   lazy val authorization: String = "Bearer " + runModeConfiguration.getString("microservice.services.des-hod.authorizationToken").getOrElse("local")
 

--- a/app/models/AcceptedInvitation.scala
+++ b/app/models/AcceptedInvitation.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+case class AcceptedInvitation(
+  pstr: String,
+  inviteePsaId: String,
+  inviterPsaId: String,
+  declaration: Boolean,
+  declarationDuties: Boolean,
+  pensionAdvisorDetail: Option[PensionAdvisorDetail]
+)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -170,6 +170,7 @@ serviceUrls {
     register.without.id.organisation = "/registration/02.00.00/organisation"
     psa.minimal.details = "/pension-online/psa-min-details/%s"
     psa.subscription.details = "/pension-online/psa-subscription-details/%s"
+    createPsaAssociation = "/pension-online/psa-association/pstr/%s"
 }
 
 microservice {

--- a/conf/resources/schemas/createPsaAssociationRequest.json
+++ b/conf/resources/schemas/createPsaAssociationRequest.json
@@ -1,0 +1,432 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "04CC -  API#1445 Post Create PSA Association  Request Schema v1.0.0",
+  "description": "04CC -  API#1445 Post Create PSA Association Request Schema v1.0.0",
+  "type": "object",
+  "properties": {
+    "psaAssociationDetails": {
+      "$ref": "#/definitions/psaAssociationDetailsType"
+    }
+  },
+  "required": [
+    "psaAssociationDetails"
+  ],
+  "additionalProperties": false,
+  "definitions": {
+    "psaAssociationDetailsType": {
+      "type": "object",
+      "properties": {
+        "psaAssociationIDsDetails": {
+          "$ref": "#/definitions/psaAssociationIDsDetailsType"
+        },
+        "declarationDetails": {
+          "$ref": "#/definitions/declarationDetailsType"
+        }
+      },
+      "required": [
+        "psaAssociationIDsDetails",
+        "declarationDetails"
+      ],
+      "additionalProperties": false
+    },
+    "psaAssociationIDsDetailsType": {
+      "type": "object",
+      "properties": {
+        "inviteePSAID": {
+          "type": "string",
+          "pattern": "^A[0-9]{7}$"
+        },
+        "inviterPSAID": {
+          "type": "string",
+          "pattern": "^A[0-9]{7}$"
+        }
+      },
+      "required": [
+        "inviteePSAID",
+        "inviterPSAID"
+      ],
+      "additionalProperties": false
+    },
+    "declarationDetailsType": {
+      "type": "object",
+      "properties": {
+        "box1": {
+          "type": "boolean"
+        },
+        "box2": {
+          "type": "boolean"
+        },
+        "box3": {
+          "type": "boolean"
+        },
+        "box4": {
+          "type": "boolean"
+        },
+        "box5": {
+          "type": "boolean"
+        },
+        "box6": {
+          "type": "boolean"
+        },
+        "pensionAdviserDetails": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "pattern": "^[a-zA-Z &?*()_À-ÿ '‘’—–‐-]{1,255}$"
+            },
+            "addressDetails": {
+              "$ref": "#/definitions/addressType"
+            },
+            "contactDetails": {
+              "$ref": "#/definitions/contactDetailsType"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "name",
+            "addressDetails",
+            "contactDetails"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "box1",
+        "box2",
+        "box3",
+        "box4"
+      ]
+    },
+    "addressType": {
+      "type": "object",
+      "properties": {
+        "nonUKAddress": {
+          "type": "boolean"
+        },
+        "line1": {
+          "$ref": "#/definitions/AddressLineType"
+        },
+        "line2": {
+          "$ref": "#/definitions/AddressLineType"
+        },
+        "line3": {
+          "$ref": "#/definitions/AddressLineType"
+        },
+        "line4": {
+          "$ref": "#/definitions/AddressLineType"
+        },
+        "postalCode": {
+          "description": "This is    populated if   the address supplied is    a   UK address.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 10
+        },
+        "countryCode": {
+          "$ref": "#/definitions/countryCodes"
+        }
+      },
+      "required": [
+        "nonUKAddress",
+        "line1",
+        "line2",
+        "countryCode"
+      ],
+      "additionalProperties": false
+    },
+    "AddressLineType": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 35,
+      "pattern": "^[A-Za-z0-9 &!'‘’\"“”(),./—–‐-]{1,35}$"
+    },
+    "contactDetailsType": {
+      "type": "object",
+      "properties": {
+        "telephone": {
+          "type": "string",
+          "pattern": "^[0-9 ()+--]{1,24}$"
+        },
+        "mobileNumber": {
+          "type": "string",
+          "pattern": "^[0-9 ()+--]{1,24}$"
+        },
+        "fax": {
+          "type": "string",
+          "pattern": "^[0-9 ()+--]{1,24}$"
+        },
+        "email": {
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 132,
+          "format": "email"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "email"
+      ]
+    },
+    "countryCodes": {
+      "type": "string",
+      "description": "Country code iso 3166-1 alpha-2",
+      "enum": [
+        "AD",
+        "AE",
+        "AF",
+        "AG",
+        "AI",
+        "AL",
+        "AM",
+        "AN",
+        "AO",
+        "AQ",
+        "AR",
+        "AS",
+        "AT",
+        "AU",
+        "AW",
+        "AX",
+        "AZ",
+        "BA",
+        "BB",
+        "BD",
+        "BE",
+        "BF",
+        "BG",
+        "BH",
+        "BI",
+        "BJ",
+        "BL",
+        "BM",
+        "BN",
+        "BO",
+        "BQ",
+        "BR",
+        "BS",
+        "BT",
+        "BV",
+        "BW",
+        "BY",
+        "BZ",
+        "CA",
+        "CC",
+        "CD",
+        "CF",
+        "CG",
+        "CH",
+        "CI",
+        "CK",
+        "CL",
+        "CM",
+        "CN",
+        "CO",
+        "CR",
+        "CS",
+        "CU",
+        "CV",
+        "CW",
+        "CX",
+        "CY",
+        "CZ",
+        "DE",
+        "DJ",
+        "DK",
+        "DM",
+        "DO",
+        "DZ",
+        "EC",
+        "EE",
+        "EG",
+        "EH",
+        "ER",
+        "ES",
+        "ET",
+        "EU",
+        "FI",
+        "FJ",
+        "FK",
+        "FM",
+        "FO",
+        "FR",
+        "GA",
+        "GB",
+        "GD",
+        "GE",
+        "GF",
+        "GG",
+        "GH",
+        "GI",
+        "GL",
+        "GM",
+        "GN",
+        "GP",
+        "GQ",
+        "GR",
+        "GS",
+        "GT",
+        "GU",
+        "GW",
+        "GY",
+        "HK",
+        "HM",
+        "HN",
+        "HR",
+        "HT",
+        "HU",
+        "ID",
+        "IE",
+        "IL",
+        "IM",
+        "IN",
+        "IO",
+        "IQ",
+        "IR",
+        "IS",
+        "IT",
+        "JE",
+        "JM",
+        "JO",
+        "JP",
+        "KE",
+        "KG",
+        "KH",
+        "KI",
+        "KM",
+        "KN",
+        "KP",
+        "KR",
+        "KW",
+        "KY",
+        "KZ",
+        "LA",
+        "LB",
+        "LC",
+        "LI",
+        "LK",
+        "LR",
+        "LS",
+        "LT",
+        "LU",
+        "LV",
+        "LY",
+        "MA",
+        "MC",
+        "MD",
+        "ME",
+        "MF",
+        "MG",
+        "MH",
+        "MK",
+        "ML",
+        "MM",
+        "MN",
+        "MO",
+        "MP",
+        "MQ",
+        "MR",
+        "MS",
+        "MT",
+        "MU",
+        "MV",
+        "MW",
+        "MX",
+        "MY",
+        "MZ",
+        "NA",
+        "NC",
+        "NE",
+        "NF",
+        "NG",
+        "NI",
+        "NL",
+        "NO",
+        "NP",
+        "NR",
+        "NT",
+        "NU",
+        "NZ",
+        "OM",
+        "PA",
+        "PE",
+        "PF",
+        "PG",
+        "PH",
+        "PK",
+        "PL",
+        "PM",
+        "PN",
+        "PR",
+        "PS",
+        "PT",
+        "PW",
+        "PY",
+        "QA",
+        "RE",
+        "RO",
+        "RS",
+        "RU",
+        "RW",
+        "SA",
+        "SB",
+        "SC",
+        "SD",
+        "SE",
+        "SG",
+        "SH",
+        "SI",
+        "SJ",
+        "SK",
+        "SL",
+        "SM",
+        "SN",
+        "SO",
+        "SR",
+        "SS",
+        "ST",
+        "SV",
+        "SX",
+        "SY",
+        "SZ",
+        "TC",
+        "TD",
+        "TF",
+        "TG",
+        "TH",
+        "TJ",
+        "TK",
+        "TL",
+        "TM",
+        "TN",
+        "TO",
+        "TP",
+        "TR",
+        "TT",
+        "TV",
+        "TW",
+        "TZ",
+        "UA",
+        "UG",
+        "UM",
+        "UN",
+        "US",
+        "UY",
+        "UZ",
+        "VA",
+        "VC",
+        "VE",
+        "VG",
+        "VI",
+        "VN",
+        "VU",
+        "WF",
+        "WS",
+        "YE",
+        "YT",
+        "ZA",
+        "ZM",
+        "ZW"
+      ]
+    }
+  }
+}

--- a/conf/resources/schemas/createPsaAssociationResponse.json
+++ b/conf/resources/schemas/createPsaAssociationResponse.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "API#1445 PODS Create PSA Association Response Schema v1.0.0",
+  "type": "object",
+  "oneOf": [
+    {
+      "$ref": "#/definitions/successResponse"
+    },
+    {
+      "$ref": "#/definitions/failureResponse"
+    }
+  ],
+  "definitions": {
+    "successResponse": {
+      "type": "object",
+      "properties": {
+        "processingDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date the message was processed"
+        },
+        "formBundleNumber": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255
+        }
+      },
+      "required": [
+        "processingDate"
+      ],
+      "additionalProperties": false
+    },
+    "failureResponse": {
+      "type": "object",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/failureResponseElement"
+        },
+        {
+          "$ref": "#/definitions/failureResponseArray"
+        }
+      ]
+    },
+    "failureResponseArray": {
+      "type": "object",
+      "properties": {
+        "failures": {
+          "type": "array",
+          "minItems": 2,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/failureResponseElement"
+          }
+        }
+      },
+      "required": [
+        "failures"
+      ],
+      "additionalProperties": false
+    },
+    "failureResponseElement": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "string",
+          "enum": [
+            "INVALID_PSTR",
+            "INVALID_PAYLOAD",
+            "INVALID_CORRELATION_ID",
+            "NOT_FOUND",
+            "INVALID_INVITEE_PSAID",
+            "INVALID_INVITER_PSAID",
+            "ACTIVE_RELATIONSHIP_EXISTS",
+            "SERVICE_UNAVAILABLE",
+            "SERVER_ERROR"
+          ],
+          "description": "Keys for all the errors returned. Custom per API"
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 160,
+          "description": "A simple description for the failure"
+        }
+      },
+      "required": [
+        "code",
+        "reason"
+      ],
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
PODS-1511: Add unit test

Work on connector

PODS-1511 Get unit test working by adding some implementation logic

PODS-1511 Tidy up

PODS-1511 Add call to connector

PODS-1511 Add call to connector

PODS-1511 Remove unused code

Revert "PODS-1511 Remove unused code"

This reverts commit 22403abb9c2e4d7364fb342fd45ff3bac08dcf00.

Revert "PODS-1511 Add call to connector"

This reverts commit 8e975834837f007fc6e533a552a54924ff80f6d8.

Revert "PODS-1511 Add call to connector"

This reverts commit 28137ccc81509a06e7224f72d25d6f9200583fda.

Address writes

Added JSON scheme files

PODS-1511 Add extra tests for different scenarios

PODS-1511 More tests

Added logging

PODS-1511 Tidy up tests - get rid of cyclomatic complexity warning

PODS-1511 Refactor

PODS-1511 Refactor

PODS-1511 Remove unit.type and change unit literal

Always log failure response

Fix merge conflicts