### PR TITLE
PODS-2590: Add splunk audit event for PSA De-enrol

### DIFF
--- a/app/audit/PSADeEnrol.scala
+++ b/app/audit/PSADeEnrol.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package audit
+
+import play.api.libs.json.{Format, JsValue, Json}
+
+case class PSADeEnrol(
+                       psaId: String,
+                       status: Int,
+                       response: Option[JsValue]
+                     ) extends AuditEvent {
+
+  override def auditType: String = "PSADeEnrol"
+
+  override def details: Map[String, String] = Map(
+    "psaId" -> psaId,
+    "status" -> status.toString,
+    "response" -> {
+      response match {
+        case Some(json) => Json.stringify(json)
+        case _ => ""
+      }
+    }
+  )
+}
+
+object PSADeEnrol {
+  implicit val formats: Format[PSADeEnrol] = Json.format[PSADeEnrol]
+}

--- a/app/audit/PSADeEnrolAuditService.scala
+++ b/app/audit/PSADeEnrolAuditService.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package audit
+
+import play.api.Logger
+import play.api.http.Status
+import play.api.libs.json.JsValue
+import play.api.mvc.RequestHeader
+import uk.gov.hmrc.http.HttpException
+
+import scala.concurrent.ExecutionContext
+import scala.util.{Failure, Success, Try}
+
+trait PSADeEnrolAuditService {
+
+  def sendPSADeEnrolEvent(psaId: String)
+                              (sendEvent: PSADeEnrol => Unit)
+                              (implicit request: RequestHeader, ec: ExecutionContext): PartialFunction[Try[Either[HttpException, JsValue]], Unit] = {
+
+    case Success(Right(response)) =>
+      sendAuditEvent(psaId, Status.OK, Some(response))(sendEvent)
+
+    case Success(Left(e)) =>
+      sendAuditEvent(psaId, e.responseCode, None)(sendEvent)
+
+    case Failure(t) =>
+      Logger.error("Error in sending audit event for PSA de-enrolment", t)
+  }
+
+  private def sendAuditEvent(psaId: String, status: Int, response: Option[JsValue])(sendEvent: PSADeEnrol => Unit): Unit
+
+  = {
+    sendEvent(
+      PSADeEnrol(
+        psaId = psaId,
+        status = status,
+        response = response)
+    )
+  }
+}

--- a/app/connectors/DesConnector.scala
+++ b/app/connectors/DesConnector.scala
@@ -75,7 +75,7 @@ class DesConnectorImpl @Inject()(
                                   psaSubscriptionDetailsTransformer: PSASubscriptionDetailsTransformer,
                                   fs: FeatureSwitchManagementService,
                                   schemeAuditService: SchemeAuditService
-                                ) extends DesConnector with HttpResponseHelper with ErrorHandler{
+                                ) extends DesConnector with HttpResponseHelper with ErrorHandler with PSADeEnrolAuditService {
 
   override def registerPSA(registerData: JsValue)(implicit
                                                   headerCarrier: HeaderCarrier,
@@ -146,7 +146,9 @@ class DesConnectorImpl @Inject()(
 
     http.POST[JsValue, HttpResponse](deregisterPsaUrl, data)(implicitly, implicitly, hc, implicitly) map {
       handlePostResponse(_, deregisterPsaUrl)
-    } andThen logFailures("deregister PSA", data, deregisterPsaSchema)
+    } andThen sendPSADeEnrolEvent(
+      psaId
+    )(auditService.sendEvent) andThen logFailures("deregister PSA", data, deregisterPsaSchema)
   }
 
   override def updatePSA(psaId: String, data: JsValue)(implicit

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -183,6 +183,12 @@ mongodb {
     }
 }
 
+mongo-async-driver {
+    akka {
+        loglevel = WARNING
+    }
+}
+
 serviceUrls {
     scheme.administrator.register = "/pension-online/subscription"
     register.with.id.individual = "/registration/individual/nino/%s"

--- a/conf/logback-test.xml
+++ b/conf/logback-test.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%-5level] %logger{15} - %msg%n%rEx</pattern>
+            <immediateFlush>false</immediateFlush>
+        </encoder>
+    </appender>
+
+    <root level="${LOG_LEVEL:-OFF}">
+        <appender-ref ref="CONSOLE" />
+    </root>
+
+</configuration>

--- a/test/audit/PSADeEnrolSpec.scala
+++ b/test/audit/PSADeEnrolSpec.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package audit
+
+import org.scalatest.{FlatSpec, Matchers}
+import play.api.libs.json.Json
+import play.api.test.Helpers._
+
+class PSADeEnrolSpec extends FlatSpec with Matchers {
+
+  private val psaId: String = "psa-id"
+  private val status: Int = OK
+  private val response = Some(Json.obj("name" -> "response"))
+
+  private val event = PSADeEnrol(
+    psaId: String,
+    status: Int,
+    response
+  )
+
+  private val expected: Map[String, String] = Map(
+    "psaId" -> psaId,
+    "status" -> status.toString,
+    "response" -> {
+      response match {
+        case Some(json) => Json.stringify(json)
+        case _ => ""
+      }
+    }
+  )
+
+  "PSADeEnrol" should "return the correct audit data" in {
+
+    event.auditType shouldBe "PSADeEnrol"
+
+    event.details shouldBe expected
+  }
+}

--- a/test/connectors/DesConnectorSpec.scala
+++ b/test/connectors/DesConnectorSpec.scala
@@ -16,7 +16,7 @@
 
 package connectors
 
-import audit.{AuditService, PSADetails, PSARemovalFromSchemeAuditEvent, StubSuccessfulAuditService}
+import audit._
 import base.JsonFileReader
 import com.github.tomakehurst.wiremock.client.WireMock.{serverError, _}
 import config.FeatureSwitchManagementService
@@ -698,6 +698,115 @@ class DesConnectorSpec extends AsyncFlatSpec
       case Left(_: NotFoundException) => succeed
     }
   }
+
+  //TODO: Test for other response codes
+  it should "send a PSADeEnrol audit event on successful deenrolment" in {
+
+    val successResponse = FakeDesConnector.deregisterPsaResponseJson
+
+    server.stubFor(
+      post(urlEqualTo(deregisterPsaUrl))
+        .withHeader("Content-Type", equalTo("application/json"))
+        .willReturn(
+          ok(Json.stringify(successResponse))
+            .withHeader("Content-Type", "application/json")
+        )
+    )
+
+    connector.deregisterPSA(psaId.value).map { _ =>
+      auditService.verifySent(
+        PSADeEnrol(
+          psaId = psaId.value,
+          status = OK,
+          response = Some(successResponse)
+        )
+      ) shouldBe true
+    }
+  }
+
+  it should "send a PSADeEnrol audit event on deenrolment failure (400)" in {
+
+    server.stubFor(
+      post(urlEqualTo(deregisterPsaUrl))
+        .willReturn(
+          badRequest
+            .withHeader("Content-Type", "application/json")
+            .withBody("INVALID_PAYLOAD")
+        )
+    )
+
+    connector.deregisterPSA(psaId.value).map {_ =>
+      auditService.verifySent(
+        PSADeEnrol(
+          psaId = psaId.value,
+          status = BAD_REQUEST,
+          response = None
+        )
+      ) shouldBe true
+    }
+
+  }
+
+  it should "send a PSADeEnrol audit event on deenrolment failure (404)" in {
+
+    server.stubFor(
+      post(urlEqualTo(deregisterPsaUrl))
+        .willReturn(
+          aResponse()
+            .withStatus(NOT_FOUND)
+            .withHeader("Content-Type", "application/json")
+            .withBody(errorResponse("NOT_FOUND"))
+        )
+    )
+
+    connector.deregisterPSA(psaId.value).map {_ =>
+      auditService.verifySent(
+        PSADeEnrol(
+          psaId = psaId.value,
+          status = NOT_FOUND,
+          response = None
+        )
+      ) shouldBe true
+    }
+
+  }
+
+  it should "send a PSADeEnrol audit event on deenrolment failure (403)" in {
+    server.stubFor(
+      post(urlEqualTo(deregisterPsaUrl))
+        .willReturn(
+          forbidden
+            .withHeader("Content-Type", "application/json")
+            .withBody(errorResponse("ALREADY_DEREGISTERED"))
+        )
+    )
+
+    connector.deregisterPSA(psaId.value).map {_ =>
+      auditService.verifySent(
+        PSADeEnrol(
+          psaId = psaId.value,
+          status = FORBIDDEN,
+          response = None
+        )
+      ) shouldBe true
+    }
+  }
+
+  it should "not send a PSADeEnrol audit event on deenrolment failure" in {
+
+    server.stubFor(
+      post(urlEqualTo(deregisterPsaUrl))
+        .willReturn(
+          serverError
+        )
+    )
+    logger.reset()
+    recoverToExceptionIf[Upstream5xxResponse](connector.deregisterPSA(psaId.value)) map {_ =>
+      auditService.verifyNothingSent shouldBe true
+    }
+
+  }
+
 
   "DesConnector updatePSA" should "handle OK (200)" in {
     val successResponse = Json.obj(

--- a/test/connectors/DesConnectorSpec.scala
+++ b/test/connectors/DesConnectorSpec.scala
@@ -699,7 +699,6 @@ class DesConnectorSpec extends AsyncFlatSpec
     }
   }
 
-  //TODO: Test for other response codes
   it should "send a PSADeEnrol audit event on successful deenrolment" in {
 
     val successResponse = FakeDesConnector.deregisterPsaResponseJson


### PR DESCRIPTION
I've added the PSADeEnrol event to be fired when a user deregisters. It logs the psaId, status code and response received from DES. I haven't logged the request because it only sends current time and a _reason_ which is always equal to 1.