### PR TITLE
queryParameter.encryption.key is removed

### DIFF
--- a/app/controllers/SchemeController.scala
+++ b/app/controllers/SchemeController.scala
@@ -55,6 +55,10 @@ class SchemeController @Inject()(schemeService: SchemeService,
 
   def getPsaDetails: Action[AnyContent] = Action.async {
     implicit request =>
+      logger.error("ERROR-LOGTEST")
+      logger.warn("WARN-LOGTEST")
+      logger.info("INFO-LOGTEST")
+      logger.debug("DEBUG-LOGTEST")
       val psaId = request.headers.get("psaId")
       psaId match {
         case Some(id) =>

--- a/conf/application-json-logger.xml
+++ b/conf/application-json-logger.xml
@@ -5,9 +5,9 @@
         <encoder class="uk.gov.hmrc.play.logging.JsonEncoder"/>
     </appender>
 
-    <logger name="uk.gov" level="${logger.uk.gov:-WARN}"/>
+    <logger name="uk.gov" level="WARN"/>
 
-    <root level="${logger.application:-WARN}">
+    <root level="WARN">
         <appender-ref ref="STDOUT"/>
     </root>
 </configuration>

--- a/conf/application-json-logger.xml
+++ b/conf/application-json-logger.xml
@@ -5,6 +5,8 @@
         <encoder class="uk.gov.hmrc.play.logging.JsonEncoder"/>
     </appender>
 
+    <logger name="uk.gov" level="WARN"/>
+
     <root level="WARN">
         <appender-ref ref="STDOUT"/>
     </root>

--- a/conf/application-json-logger.xml
+++ b/conf/application-json-logger.xml
@@ -7,7 +7,7 @@
 
     <logger name="uk.gov" level="WARN"/>
 
-    <root level="WARN">
+    <root level="DEBUG">
         <appender-ref ref="STDOUT"/>
     </root>
 </configuration>

--- a/conf/application-json-logger.xml
+++ b/conf/application-json-logger.xml
@@ -5,8 +5,6 @@
         <encoder class="uk.gov.hmrc.play.logging.JsonEncoder"/>
     </appender>
 
-    <logger name="uk.gov" level="WARN"/>
-
     <root level="WARN">
         <appender-ref ref="STDOUT"/>
     </root>

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -119,19 +119,6 @@ controllers {
 # You can disable evolutions if needed
 # evolutionplugin=disabled
 
-# Logger
-# ~~~~~
-# You can also configure logback (http://logback.qos.ch/), by providing a logger.xml file in the conf directory .
-
-# Root logger:
-logger.root=ERROR
-
-# Logger used by the framework:
-logger.play=INFO
-
-# Logger provided to your application:
-logger.application=DEBUG
-
 # Metrics plugin settings - graphite reporting is configured on a per env basis
 metrics {
     name = ${appName}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -71,6 +71,9 @@ encrypted = false
 #Determines whether the feature toggle is in Production mode or test mode
 enable-dynamic-switches: true
 
+# this key is for local development only!
+queryParameter.encryption.key="gvBoGdgzqG1AarzF1LY0zQ=="
+
 # Session configuration
 # ~~~~~
 application.session.httpOnly=false

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -71,9 +71,6 @@ encrypted = false
 #Determines whether the feature toggle is in Production mode or test mode
 enable-dynamic-switches: true
 
-# this key is for local development only!
-queryParameter.encryption.key="gvBoGdgzqG1AarzF1LY0zQ=="
-
 # Session configuration
 # ~~~~~
 application.session.httpOnly=false

--- a/conf/logback-test.xml
+++ b/conf/logback-test.xml
@@ -8,7 +8,7 @@
         </encoder>
     </appender>
 
-    <root level="${LOG_LEVEL:-OFF}">
+    <root level="INFO">
         <appender-ref ref="CONSOLE" />
     </root>
 


### PR DESCRIPTION
Useful docs:
https://www.digitalocean.com/community/tutorials/log4j-levels-example-order-priority-custom-filters
https://confluence.tools.tax.service.gov.uk/pages/viewpage.action?spaceKey=TEC&postingDay=2021%2F12%2F13&title=Simplified+log+configuration+for+services
